### PR TITLE
Next Release

### DIFF
--- a/.github/workflows/develop-func-ci.yml
+++ b/.github/workflows/develop-func-ci.yml
@@ -21,6 +21,6 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: fastify/github-action-merge-dependabot@v3.5.3
+      - uses: fastify/github-action-merge-dependabot@v3.5.4
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/develop-func-ci.yml
+++ b/.github/workflows/develop-func-ci.yml
@@ -21,6 +21,6 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: fastify/github-action-merge-dependabot@v3.5.1
+      - uses: fastify/github-action-merge-dependabot@v3.5.2
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/develop-func-ci.yml
+++ b/.github/workflows/develop-func-ci.yml
@@ -21,6 +21,6 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: fastify/github-action-merge-dependabot@v3.5.2
+      - uses: fastify/github-action-merge-dependabot@v3.5.3
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,5 @@ test_data
 test/test_files
 node_modules
 iati-rulesets
-schemas
 var
 *.sef.json

--- a/Download/index.js
+++ b/Download/index.js
@@ -104,6 +104,13 @@ export default async function download(context) {
 
             queryUrl.searchParams.set('rows', config.SOLR_MAX_ROWS);
 
+            const uploadResponsePromise = blockBlobClient.uploadStream(
+                uploadStream,
+                uploadOptions.bufferSize,
+                uploadOptions.maxBuffers,
+                uploadConfig
+            );
+
             do {
                 context.log(
                     `Downloading ${start}-${
@@ -129,12 +136,7 @@ export default async function download(context) {
             uploadStream.write(footer);
             uploadStream.end();
 
-            uploadResponse = await blockBlobClient.uploadStream(
-                uploadStream,
-                uploadOptions.bufferSize,
-                uploadOptions.maxBuffers,
-                uploadConfig
-            );
+            uploadResponse = await uploadResponsePromise;
         } else {
             // JSON, CSV, EXCEL - request all rows and stream directly to blob
             queryUrl.searchParams.set('rows', numFound);

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # datastore-services
 
+## Endpoints
+
+See OpenAPI specification `postman/schemas/index.yaml`. To view locally in Swagger UI, you can use the `42crunch.vscode-openapi` VSCode extension.
+
 ## Prerequisities
 
 -   nvm - [nvm](https://github.com/nvm-sh/nvm) - Node version manager
@@ -103,92 +107,11 @@ let myEnvVariable = config.ENV_VAR
 -   This is done with eslint following the airbnb-base style and using [Prettier](https://prettier.io). Implemented with [this](https://sourcelevel.io/blog/how-to-setup-eslint-and-prettier-on-node) guide.
 -   If you use VSCode the formatting will happen automagically on save due to the `.vscode/settings.json` > `"editor.formatOnSave": true` setting
 
-## Endpoints /api
-
-### `GET /pub/version`
-
--   Returns application version from `package.json`
-
-```
-<0.0.0>
-```
-
-### `PATCH pvt/db/solr-reindex`
-
--   Request
-
-```json
-{ "ids": ["74790f8d-29f7-4bda-afa9-b46070dfc276", "547d7d97-9330-4938-bc4b-f64c3844be23"] }
-```
-
--   Returns
-
-204 Response
-
-### `PATCH /pvt/db/solr-reindex/all`
-
--   Returns
-
-204 Response
-
-### `PATCH /pvt/db/clear-flattener`
-
--   Request
-
-```json
-{ "ids": ["74790f8d-29f7-4bda-afa9-b46070dfc276", "547d7d97-9330-4938-bc4b-f64c3844be23"] }
-```
-
--   Returns
-
-204 Response
-
-### `PATCH /pvt/db/clear-flattener/all`
-
--   Returns
-
-204 Response
-
-### `POST /pvt/solr/create-collections`
-
-Creates new collections named `collection.name_newVersion`, aliases to `collection.alias`
-
--   Request
-
-```json
-{
-  "newVersion": "4",
-  "collections": [
-    {
-      "name": "activity",
-      "config": {
-        "collection.configName": "activity_configset_4",
-        "numShards": 1,
-        "replicationFactor": 1
-      },
-      "alias": "activity_solrize"
-    },
-    {
-      "name": "budget",
-      "config": {
-        "collection.configName": "budget_configset_4",
-        "numShards": 1,
-        "replicationFactor": 1
-      },
-      "alias": "budget_solrize"
-    }
-    ...
-  ]
-}
-```
-
-Also see [exampleRequest.json](./pvt-post-solr-create-collections/exampleRequest.json)
-
--   Returns
-
-204 Response
+## Endpoints notes
 
 ### `POST /pvt/orchestrators/DownloadOrchestrator`
+
+https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview?tabs=csharp#async-http
 
 Downloads the provided Solr query to Azure Blobs and returns URL where it can be downloaded from.
 

--- a/integration-tests/datastore-services-integration-tests.postman_collection.json
+++ b/integration-tests/datastore-services-integration-tests.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "cfae2a04-a74e-48ad-bf80-f81e28075d74",
+		"_postman_id": "ccce44b4-f339-4cba-ae35-ee1ef20e5df5",
 		"name": "datastore-services-integration-tests",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "13097277"
@@ -418,6 +418,68 @@
 										"body": {
 											"mode": "raw",
 											"raw": "{\n    \"query\": \"activity/search?q=iati_identifier:\\\"GB-COH-06368740-P0055\\\"&fl=iati_identifier,reporting_org_ref,reporting_org_type\",\n    \"format\": \"XML\"\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{baseURL}}/orchestrators/DownloadOrchestrator",
+											"host": [
+												"{{baseURL}}"
+											],
+											"path": [
+												"orchestrators",
+												"DownloadOrchestrator"
+											]
+										},
+										"description": "42.75 MiB"
+									},
+									"response": []
+								},
+								{
+									"name": "Download Solr Query - Test Pagination (Only for XML response format)",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"const statusResponse = pm.collectionVariables.get(\"statusResponseBody\");",
+													"",
+													"pm.test(\"Number of results found to be greater than 1000 activities to ensure pagination is happening\", function () {",
+													"    pm.expect(statusResponse.output.solrResponseMeta.numFound).to.be.greaterThan(1000)",
+													"});",
+													"",
+													"// HEAD request to blob URL, check response, header and size",
+													"const downloadHeadReq = {",
+													"    url: statusResponse.output.url,",
+													"    method: 'HEAD'",
+													"}",
+													"",
+													"pm.sendRequest(downloadHeadReq, function (err, response) {",
+													"    pm.test(\"File download status code is 200\", function () {",
+													"        pm.expect(response.code).to.eql(200);",
+													"    });",
+													"    pm.test(\"File download Content-Disposition header is present and contains 'attachment'\", function () {",
+													"        pm.expect(response.headers.find(h => h.key == \"Content-Disposition\").value).to.contain('attachment');",
+													"    });",
+													"    const fileSize = response.headers.find(h => h.key == \"Content-Length\").value / (1024*1024)",
+													"    const { format } = statusResponse.output.req",
+													"    console.log(`${format} File Size (MiB): ${fileSize}`)",
+													"});",
+													""
+												],
+												"type": "text/javascript"
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"query\": \"activity/search?q=sector_code:11120\",\n    \"format\": \"XML\"\n}",
 											"options": {
 												"raw": {
 													"language": "json"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "@prettier/plugin-xml": "^2.2.0",
                 "eslint": "^8.30.0",
                 "eslint-config-airbnb-base": "^15.0.0",
-                "eslint-config-prettier": "^8.5.0",
+                "eslint-config-prettier": "^8.6.0",
                 "eslint-plugin-import": "^2.26.0",
                 "husky": "^8.0.2",
                 "lint-staged": "^13.1.0",
@@ -969,9 +969,9 @@
             }
         },
         "node_modules/eslint-config-prettier": {
-            "version": "8.5.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-            "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+            "version": "8.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
+            "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
             "dev": true,
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
@@ -4225,9 +4225,9 @@
             }
         },
         "eslint-config-prettier": {
-            "version": "8.5.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-            "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+            "version": "8.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
+            "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
             "dev": true,
             "requires": {}
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "eslint-config-airbnb-base": "^15.0.0",
                 "eslint-config-prettier": "^8.6.0",
                 "eslint-plugin-import": "^2.26.0",
-                "husky": "^8.0.2",
+                "husky": "^8.0.3",
                 "lint-staged": "^13.1.0",
                 "prettier": "^2.8.1"
             },
@@ -1626,9 +1626,9 @@
             }
         },
         "node_modules/husky": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.2.tgz",
-            "integrity": "sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==",
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+            "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
             "dev": true,
             "bin": {
                 "husky": "lib/bin.js"
@@ -4649,9 +4649,9 @@
             "dev": true
         },
         "husky": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.2.tgz",
-            "integrity": "sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==",
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+            "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
             "dev": true
         },
         "ignore": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "eslint-plugin-import": "^2.26.0",
                 "husky": "^8.0.2",
                 "lint-staged": "^13.0.3",
-                "prettier": "^2.7.1"
+                "prettier": "^2.8.0"
             },
             "engines": {
                 "node": ">=16 <17",
@@ -2714,9 +2714,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-            "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+            "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
             "dev": true,
             "bin": {
                 "prettier": "bin-prettier.js"
@@ -5417,9 +5417,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-            "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+            "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
             "dev": true
         },
         "process": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "datastore-services",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "datastore-services",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "dependencies": {
                 "@azure/storage-blob": "^12.12.0",
                 "chardet": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
             },
             "devDependencies": {
                 "@prettier/plugin-xml": "^2.2.0",
-                "eslint": "^8.29.0",
+                "eslint": "^8.30.0",
                 "eslint-config-airbnb-base": "^15.0.0",
                 "eslint-config-prettier": "^8.5.0",
                 "eslint-plugin-import": "^2.26.0",
@@ -184,15 +184,15 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-            "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.0.tgz",
+            "integrity": "sha512-7yfvXy6MWLgWSFsLhz5yH3iQ52St8cdUY6FoGieKkRDVxuxmrNuUetIuu6cmjNWwniUHiWXjxCr5tTXDrbYS5A==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
                 "espree": "^9.4.0",
-                "globals": "^13.15.0",
+                "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^4.1.0",
@@ -207,14 +207,14 @@
             }
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.6",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.6.tgz",
-            "integrity": "sha512-jJr+hPTJYKyDILJfhNSHsjiwXYf26Flsz8DvNndOsHs5pwSnpGUEy8yzF0JYhCEvTDdV2vuOK5tt8BVhwO5/hg==",
+            "version": "0.11.8",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+            "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
             "dev": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^1.2.1",
                 "debug": "^4.1.1",
-                "minimatch": "^3.0.4"
+                "minimatch": "^3.0.5"
             },
             "engines": {
                 "node": ">=10.10.0"
@@ -343,9 +343,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.8.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-            "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+            "version": "8.8.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -885,13 +885,13 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.29.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
-            "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
+            "version": "8.30.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.30.0.tgz",
+            "integrity": "sha512-MGADB39QqYuzEGov+F/qb18r4i7DohCDOfatHaxI2iGlPuC65bwG2gxgO+7DkyL38dRFaRH7RaRAgU6JKL9rMQ==",
             "dev": true,
             "dependencies": {
-                "@eslint/eslintrc": "^1.3.3",
-                "@humanwhocodes/config-array": "^0.11.6",
+                "@eslint/eslintrc": "^1.4.0",
+                "@humanwhocodes/config-array": "^0.11.8",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
                 "ajv": "^6.10.0",
@@ -910,7 +910,7 @@
                 "file-entry-cache": "^6.0.1",
                 "find-up": "^5.0.0",
                 "glob-parent": "^6.0.2",
-                "globals": "^13.15.0",
+                "globals": "^13.19.0",
                 "grapheme-splitter": "^1.0.4",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.0.0",
@@ -1207,9 +1207,9 @@
             }
         },
         "node_modules/espree": {
-            "version": "9.4.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
-            "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+            "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
             "dev": true,
             "dependencies": {
                 "acorn": "^8.8.0",
@@ -1551,9 +1551,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "13.17.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-            "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+            "version": "13.19.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
+            "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
             "dev": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
@@ -1641,9 +1641,9 @@
             }
         },
         "node_modules/ignore": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+            "version": "5.2.4",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+            "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
             "dev": true,
             "engines": {
                 "node": ">= 4"
@@ -3564,15 +3564,15 @@
             }
         },
         "@eslint/eslintrc": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-            "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.0.tgz",
+            "integrity": "sha512-7yfvXy6MWLgWSFsLhz5yH3iQ52St8cdUY6FoGieKkRDVxuxmrNuUetIuu6cmjNWwniUHiWXjxCr5tTXDrbYS5A==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
                 "espree": "^9.4.0",
-                "globals": "^13.15.0",
+                "globals": "^13.19.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^4.1.0",
@@ -3581,14 +3581,14 @@
             }
         },
         "@humanwhocodes/config-array": {
-            "version": "0.11.6",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.6.tgz",
-            "integrity": "sha512-jJr+hPTJYKyDILJfhNSHsjiwXYf26Flsz8DvNndOsHs5pwSnpGUEy8yzF0JYhCEvTDdV2vuOK5tt8BVhwO5/hg==",
+            "version": "0.11.8",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+            "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
             "dev": true,
             "requires": {
                 "@humanwhocodes/object-schema": "^1.2.1",
                 "debug": "^4.1.1",
-                "minimatch": "^3.0.4"
+                "minimatch": "^3.0.5"
             }
         },
         "@humanwhocodes/module-importer": {
@@ -3694,9 +3694,9 @@
             }
         },
         "acorn": {
-            "version": "8.8.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
-            "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+            "version": "8.8.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
             "dev": true
         },
         "acorn-jsx": {
@@ -4107,13 +4107,13 @@
             }
         },
         "eslint": {
-            "version": "8.29.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
-            "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
+            "version": "8.30.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.30.0.tgz",
+            "integrity": "sha512-MGADB39QqYuzEGov+F/qb18r4i7DohCDOfatHaxI2iGlPuC65bwG2gxgO+7DkyL38dRFaRH7RaRAgU6JKL9rMQ==",
             "dev": true,
             "requires": {
-                "@eslint/eslintrc": "^1.3.3",
-                "@humanwhocodes/config-array": "^0.11.6",
+                "@eslint/eslintrc": "^1.4.0",
+                "@humanwhocodes/config-array": "^0.11.8",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
                 "ajv": "^6.10.0",
@@ -4132,7 +4132,7 @@
                 "file-entry-cache": "^6.0.1",
                 "find-up": "^5.0.0",
                 "glob-parent": "^6.0.2",
-                "globals": "^13.15.0",
+                "globals": "^13.19.0",
                 "grapheme-splitter": "^1.0.4",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.0.0",
@@ -4354,9 +4354,9 @@
             "dev": true
         },
         "espree": {
-            "version": "9.4.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.0.tgz",
-            "integrity": "sha512-DQmnRpLj7f6TgN/NYb0MTzJXL+vJF9h3pHy4JhCIs3zwcgez8xmGg3sXHcEO97BrmO2OSvCwMdfdlyl+E9KjOw==",
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.4.1.tgz",
+            "integrity": "sha512-XwctdmTO6SIvCzd9810yyNzIrOrqNYV9Koizx4C/mRhf9uq0o4yHoCEU/670pOxOL/MSraektvSAji79kX90Vg==",
             "dev": true,
             "requires": {
                 "acorn": "^8.8.0",
@@ -4598,9 +4598,9 @@
             }
         },
         "globals": {
-            "version": "13.17.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-            "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+            "version": "13.19.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
+            "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
             "dev": true,
             "requires": {
                 "type-fest": "^0.20.2"
@@ -4655,9 +4655,9 @@
             "dev": true
         },
         "ignore": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+            "version": "5.2.4",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+            "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
             "dev": true
         },
         "import-fresh": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
             },
             "devDependencies": {
                 "@prettier/plugin-xml": "^2.2.0",
-                "eslint": "^8.28.0",
+                "eslint": "^8.29.0",
                 "eslint-config-airbnb-base": "^15.0.0",
                 "eslint-config-prettier": "^8.5.0",
                 "eslint-plugin-import": "^2.26.0",
@@ -885,9 +885,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.28.0.tgz",
-            "integrity": "sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==",
+            "version": "8.29.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
+            "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
             "dev": true,
             "dependencies": {
                 "@eslint/eslintrc": "^1.3.3",
@@ -4107,9 +4107,9 @@
             }
         },
         "eslint": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.28.0.tgz",
-            "integrity": "sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==",
+            "version": "8.29.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.29.0.tgz",
+            "integrity": "sha512-isQ4EEiyUjZFbEKvEGJKKGBwXtvXX+zJbkVKCgTuB9t/+jUBcy8avhkEwWJecI15BkRkOYmvIM5ynbhRjEkoeg==",
             "dev": true,
             "requires": {
                 "@eslint/eslintrc": "^1.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.6.1",
             "dependencies": {
                 "@azure/storage-blob": "^12.12.0",
-                "chardet": "^1.5.0",
+                "chardet": "^1.5.1",
                 "dotenv": "^16.0.3",
                 "durable-functions": "^2.1.0",
                 "node-fetch": "^3.2.10",
@@ -600,9 +600,9 @@
             }
         },
         "node_modules/chardet": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.5.0.tgz",
-            "integrity": "sha512-Nj3VehbbFs/1ZnJJJaL3ztEf3Nu5Fs6YV/NBs6lyz/iDDHUU+X9QNk5QgPy1/5Rjtb/cGVf+NyazP7kVEJqKRg=="
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.5.1.tgz",
+            "integrity": "sha512-0XMOtA52igKDOIfvJZJ6v0+J9yMF3IuYyEa5oFUxBXA01G6mwCNKpul3bgbFf7lmZuqwN/oyg/zQ1cGS7NyJkQ=="
         },
         "node_modules/chevrotain": {
             "version": "7.1.1",
@@ -3883,9 +3883,9 @@
             }
         },
         "chardet": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.5.0.tgz",
-            "integrity": "sha512-Nj3VehbbFs/1ZnJJJaL3ztEf3Nu5Fs6YV/NBs6lyz/iDDHUU+X9QNk5QgPy1/5Rjtb/cGVf+NyazP7kVEJqKRg=="
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-1.5.1.tgz",
+            "integrity": "sha512-0XMOtA52igKDOIfvJZJ6v0+J9yMF3IuYyEa5oFUxBXA01G6mwCNKpul3bgbFf7lmZuqwN/oyg/zQ1cGS7NyJkQ=="
         },
         "chevrotain": {
             "version": "7.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
             },
             "devDependencies": {
                 "@prettier/plugin-xml": "^2.2.0",
-                "eslint": "^8.30.0",
+                "eslint": "^8.31.0",
                 "eslint-config-airbnb-base": "^15.0.0",
                 "eslint-config-prettier": "^8.6.0",
                 "eslint-plugin-import": "^2.26.0",
@@ -184,9 +184,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.0.tgz",
-            "integrity": "sha512-7yfvXy6MWLgWSFsLhz5yH3iQ52St8cdUY6FoGieKkRDVxuxmrNuUetIuu6cmjNWwniUHiWXjxCr5tTXDrbYS5A==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
+            "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
             "dev": true,
             "dependencies": {
                 "ajv": "^6.12.4",
@@ -885,12 +885,12 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.30.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.30.0.tgz",
-            "integrity": "sha512-MGADB39QqYuzEGov+F/qb18r4i7DohCDOfatHaxI2iGlPuC65bwG2gxgO+7DkyL38dRFaRH7RaRAgU6JKL9rMQ==",
+            "version": "8.31.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.31.0.tgz",
+            "integrity": "sha512-0tQQEVdmPZ1UtUKXjX7EMm9BlgJ08G90IhWh0PKDCb3ZLsgAOHI8fYSIzYVZej92zsgq+ft0FGsxhJ3xo2tbuA==",
             "dev": true,
             "dependencies": {
-                "@eslint/eslintrc": "^1.4.0",
+                "@eslint/eslintrc": "^1.4.1",
                 "@humanwhocodes/config-array": "^0.11.8",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
@@ -3564,9 +3564,9 @@
             }
         },
         "@eslint/eslintrc": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.0.tgz",
-            "integrity": "sha512-7yfvXy6MWLgWSFsLhz5yH3iQ52St8cdUY6FoGieKkRDVxuxmrNuUetIuu6cmjNWwniUHiWXjxCr5tTXDrbYS5A==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
+            "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
@@ -4107,12 +4107,12 @@
             }
         },
         "eslint": {
-            "version": "8.30.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.30.0.tgz",
-            "integrity": "sha512-MGADB39QqYuzEGov+F/qb18r4i7DohCDOfatHaxI2iGlPuC65bwG2gxgO+7DkyL38dRFaRH7RaRAgU6JKL9rMQ==",
+            "version": "8.31.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.31.0.tgz",
+            "integrity": "sha512-0tQQEVdmPZ1UtUKXjX7EMm9BlgJ08G90IhWh0PKDCb3ZLsgAOHI8fYSIzYVZej92zsgq+ft0FGsxhJ3xo2tbuA==",
             "dev": true,
             "requires": {
-                "@eslint/eslintrc": "^1.4.0",
+                "@eslint/eslintrc": "^1.4.1",
                 "@humanwhocodes/config-array": "^0.11.8",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "eslint-plugin-import": "^2.26.0",
                 "husky": "^8.0.2",
                 "lint-staged": "^13.1.0",
-                "prettier": "^2.8.0"
+                "prettier": "^2.8.1"
             },
             "engines": {
                 "node": ">=16 <17",
@@ -2714,9 +2714,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
-            "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+            "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
             "dev": true,
             "bin": {
                 "prettier": "bin-prettier.js"
@@ -5417,9 +5417,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
-            "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
+            "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
             "dev": true
         },
         "process": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "eslint-config-prettier": "^8.5.0",
                 "eslint-plugin-import": "^2.26.0",
                 "husky": "^8.0.2",
-                "lint-staged": "^13.0.3",
+                "lint-staged": "^13.0.4",
                 "prettier": "^2.8.0"
             },
             "engines": {
@@ -669,9 +669,9 @@
             "dev": true
         },
         "node_modules/colorette": {
-            "version": "2.0.17",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.17.tgz",
-            "integrity": "sha512-hJo+3Bkn0NCHybn9Tu35fIeoOKGOk5OCC32y4Hz2It+qlCO2Q3DeQ1hRn/tDDMQKRYUEzqsl7jbF6dYKjlE60g==",
+            "version": "2.0.19",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+            "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
             "dev": true
         },
         "node_modules/combined-stream": {
@@ -686,9 +686,9 @@
             }
         },
         "node_modules/commander": {
-            "version": "9.3.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-9.3.0.tgz",
-            "integrity": "sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==",
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+            "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
             "dev": true,
             "engines": {
                 "node": "^12.20.0 || >=14"
@@ -1986,33 +1986,33 @@
             }
         },
         "node_modules/lilconfig": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
-            "integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+            "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
             "dev": true,
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/lint-staged": {
-            "version": "13.0.3",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.0.3.tgz",
-            "integrity": "sha512-9hmrwSCFroTSYLjflGI8Uk+GWAwMB4OlpU4bMJEAT5d/llQwtYKoim4bLOyLCuWFAhWEupE0vkIFqtw/WIsPug==",
+            "version": "13.0.4",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.0.4.tgz",
+            "integrity": "sha512-HxlHCXoYRsq9QCby5wFozmZW00hMs/9e3l+/dz6Qr8Kle4UH0kJTdABAbqhzG+3pcG6QjL9kz7NgGBfph+a5dw==",
             "dev": true,
             "dependencies": {
                 "cli-truncate": "^3.1.0",
-                "colorette": "^2.0.17",
-                "commander": "^9.3.0",
+                "colorette": "^2.0.19",
+                "commander": "^9.4.1",
                 "debug": "^4.3.4",
                 "execa": "^6.1.0",
-                "lilconfig": "2.0.5",
-                "listr2": "^4.0.5",
+                "lilconfig": "2.0.6",
+                "listr2": "^5.0.5",
                 "micromatch": "^4.0.5",
                 "normalize-path": "^3.0.0",
                 "object-inspect": "^1.12.2",
                 "pidtree": "^0.6.0",
                 "string-argv": "^0.3.1",
-                "yaml": "^2.1.1"
+                "yaml": "^2.1.3"
             },
             "bin": {
                 "lint-staged": "bin/lint-staged.js"
@@ -2025,22 +2025,22 @@
             }
         },
         "node_modules/listr2": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
-            "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.5.tgz",
+            "integrity": "sha512-DpBel6fczu7oQKTXMekeprc0o3XDgGMkD7JNYyX+X0xbwK+xgrx9dcyKoXKqpLSUvAWfmoePS7kavniOcq3r4w==",
             "dev": true,
             "dependencies": {
                 "cli-truncate": "^2.1.0",
-                "colorette": "^2.0.16",
+                "colorette": "^2.0.19",
                 "log-update": "^4.0.0",
                 "p-map": "^4.0.0",
                 "rfdc": "^1.3.0",
-                "rxjs": "^7.5.5",
+                "rxjs": "^7.5.6",
                 "through": "^2.3.8",
                 "wrap-ansi": "^7.0.0"
             },
             "engines": {
-                "node": ">=12"
+                "node": "^14.13.1 || >=16.0.0"
             },
             "peerDependencies": {
                 "enquirer": ">= 2.3.0 < 3"
@@ -2891,9 +2891,9 @@
             }
         },
         "node_modules/rxjs": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
-            "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+            "version": "7.5.7",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+            "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
             "dev": true,
             "dependencies": {
                 "tslib": "^2.1.0"
@@ -3147,7 +3147,7 @@
         "node_modules/through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
             "dev": true
         },
         "node_modules/to-regex-range": {
@@ -3425,9 +3425,9 @@
             }
         },
         "node_modules/yaml": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-            "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
+            "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
             "dev": true,
             "engines": {
                 "node": ">= 14"
@@ -3937,9 +3937,9 @@
             "dev": true
         },
         "colorette": {
-            "version": "2.0.17",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.17.tgz",
-            "integrity": "sha512-hJo+3Bkn0NCHybn9Tu35fIeoOKGOk5OCC32y4Hz2It+qlCO2Q3DeQ1hRn/tDDMQKRYUEzqsl7jbF6dYKjlE60g==",
+            "version": "2.0.19",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+            "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
             "dev": true
         },
         "combined-stream": {
@@ -3951,9 +3951,9 @@
             }
         },
         "commander": {
-            "version": "9.3.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-9.3.0.tgz",
-            "integrity": "sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==",
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+            "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
             "dev": true
         },
         "concat-map": {
@@ -4898,44 +4898,44 @@
             }
         },
         "lilconfig": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
-            "integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+            "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
             "dev": true
         },
         "lint-staged": {
-            "version": "13.0.3",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.0.3.tgz",
-            "integrity": "sha512-9hmrwSCFroTSYLjflGI8Uk+GWAwMB4OlpU4bMJEAT5d/llQwtYKoim4bLOyLCuWFAhWEupE0vkIFqtw/WIsPug==",
+            "version": "13.0.4",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.0.4.tgz",
+            "integrity": "sha512-HxlHCXoYRsq9QCby5wFozmZW00hMs/9e3l+/dz6Qr8Kle4UH0kJTdABAbqhzG+3pcG6QjL9kz7NgGBfph+a5dw==",
             "dev": true,
             "requires": {
                 "cli-truncate": "^3.1.0",
-                "colorette": "^2.0.17",
-                "commander": "^9.3.0",
+                "colorette": "^2.0.19",
+                "commander": "^9.4.1",
                 "debug": "^4.3.4",
                 "execa": "^6.1.0",
-                "lilconfig": "2.0.5",
-                "listr2": "^4.0.5",
+                "lilconfig": "2.0.6",
+                "listr2": "^5.0.5",
                 "micromatch": "^4.0.5",
                 "normalize-path": "^3.0.0",
                 "object-inspect": "^1.12.2",
                 "pidtree": "^0.6.0",
                 "string-argv": "^0.3.1",
-                "yaml": "^2.1.1"
+                "yaml": "^2.1.3"
             }
         },
         "listr2": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.5.tgz",
-            "integrity": "sha512-juGHV1doQdpNT3GSTs9IUN43QJb7KHdF9uqg7Vufs/tG9VTzpFphqF4pm/ICdAABGQxsyNn9CiYA3StkI6jpwA==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.5.tgz",
+            "integrity": "sha512-DpBel6fczu7oQKTXMekeprc0o3XDgGMkD7JNYyX+X0xbwK+xgrx9dcyKoXKqpLSUvAWfmoePS7kavniOcq3r4w==",
             "dev": true,
             "requires": {
                 "cli-truncate": "^2.1.0",
-                "colorette": "^2.0.16",
+                "colorette": "^2.0.19",
                 "log-update": "^4.0.0",
                 "p-map": "^4.0.0",
                 "rfdc": "^1.3.0",
-                "rxjs": "^7.5.5",
+                "rxjs": "^7.5.6",
                 "through": "^2.3.8",
                 "wrap-ansi": "^7.0.0"
             },
@@ -5523,9 +5523,9 @@
             }
         },
         "rxjs": {
-            "version": "7.5.5",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
-            "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+            "version": "7.5.7",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
+            "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
             "dev": true,
             "requires": {
                 "tslib": "^2.1.0"
@@ -5703,7 +5703,7 @@
         "through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
             "dev": true
         },
         "to-regex-range": {
@@ -5917,9 +5917,9 @@
             "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
         },
         "yaml": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.1.tgz",
-            "integrity": "sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
+            "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
             "dev": true
         },
         "yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "eslint-config-prettier": "^8.5.0",
                 "eslint-plugin-import": "^2.26.0",
                 "husky": "^8.0.2",
-                "lint-staged": "^13.0.4",
+                "lint-staged": "^13.1.0",
                 "prettier": "^2.8.0"
             },
             "engines": {
@@ -1995,9 +1995,9 @@
             }
         },
         "node_modules/lint-staged": {
-            "version": "13.0.4",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.0.4.tgz",
-            "integrity": "sha512-HxlHCXoYRsq9QCby5wFozmZW00hMs/9e3l+/dz6Qr8Kle4UH0kJTdABAbqhzG+3pcG6QjL9kz7NgGBfph+a5dw==",
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.1.0.tgz",
+            "integrity": "sha512-pn/sR8IrcF/T0vpWLilih8jmVouMlxqXxKuAojmbiGX5n/gDnz+abdPptlj0vYnbfE0SQNl3CY/HwtM0+yfOVQ==",
             "dev": true,
             "dependencies": {
                 "cli-truncate": "^3.1.0",
@@ -4904,9 +4904,9 @@
             "dev": true
         },
         "lint-staged": {
-            "version": "13.0.4",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.0.4.tgz",
-            "integrity": "sha512-HxlHCXoYRsq9QCby5wFozmZW00hMs/9e3l+/dz6Qr8Kle4UH0kJTdABAbqhzG+3pcG6QjL9kz7NgGBfph+a5dw==",
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.1.0.tgz",
+            "integrity": "sha512-pn/sR8IrcF/T0vpWLilih8jmVouMlxqXxKuAojmbiGX5n/gDnz+abdPptlj0vYnbfE0SQNl3CY/HwtM0+yfOVQ==",
             "dev": true,
             "requires": {
                 "cli-truncate": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-import": "^2.26.0",
-        "husky": "^8.0.2",
+        "husky": "^8.0.3",
         "lint-staged": "^13.1.0",
         "prettier": "^2.8.1"
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "@prettier/plugin-xml": "^2.2.0",
         "eslint": "^8.30.0",
         "eslint-config-airbnb-base": "^15.0.0",
-        "eslint-config-prettier": "^8.5.0",
+        "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-import": "^2.26.0",
         "husky": "^8.0.2",
         "lint-staged": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",
         "husky": "^8.0.2",
-        "lint-staged": "^13.0.4",
+        "lint-staged": "^13.1.0",
         "prettier": "^2.8.0"
     },
     "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "eslint-plugin-import": "^2.26.0",
         "husky": "^8.0.2",
         "lint-staged": "^13.1.0",
-        "prettier": "^2.8.0"
+        "prettier": "^2.8.1"
     },
     "lint-staged": {
         "*.js": "eslint --cache --fix",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     },
     "devDependencies": {
         "@prettier/plugin-xml": "^2.2.0",
-        "eslint": "^8.29.0",
+        "eslint": "^8.30.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     },
     "devDependencies": {
         "@prettier/plugin-xml": "^2.2.0",
-        "eslint": "^8.30.0",
+        "eslint": "^8.31.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-import": "^2.26.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     },
     "devDependencies": {
         "@prettier/plugin-xml": "^2.2.0",
-        "eslint": "^8.28.0",
+        "eslint": "^8.29.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "datastore-services",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "description": "Datastore utility endpoints",
     "type": "module",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",
         "husky": "^8.0.2",
-        "lint-staged": "^13.0.3",
+        "lint-staged": "^13.0.4",
         "prettier": "^2.8.0"
     },
     "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "eslint-plugin-import": "^2.26.0",
         "husky": "^8.0.2",
         "lint-staged": "^13.0.3",
-        "prettier": "^2.7.1"
+        "prettier": "^2.8.0"
     },
     "lint-staged": {
         "*.js": "eslint --cache --fix",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "author": "IATI",
     "dependencies": {
         "@azure/storage-blob": "^12.12.0",
-        "chardet": "^1.5.0",
+        "chardet": "^1.5.1",
         "dotenv": "^16.0.3",
         "durable-functions": "^2.1.0",
         "node-fetch": "^3.2.10",

--- a/postman/schemas/index.yaml
+++ b/postman/schemas/index.yaml
@@ -1,0 +1,395 @@
+openapi: '3.0.0'
+info:
+    version: '1.6.0'
+    title: 'datastore-services'
+    description: Service and utility endpoints for the IATI Datastore
+
+servers:
+    - url: 'http://localhost:7071'
+      description: Local Function
+    - url: 'https://func-datastore-services-dev.azurewebsites.net'
+      description: Dev environment Function (requires auth)
+    - url: 'https://func-datastore-services-prod.azurewebsites.net'
+      description: Production environment Function (requires auth)
+
+paths:
+    /api/pvt/version:
+        get:
+            summary: Returns application version.
+            responses:
+                200:
+                    description: Version of the application in semver format
+                    content:
+                        text/plain:
+                            schema:
+                                type: string
+                                example: 1.0.7
+                401:
+                    $ref: '#/components/responses/UnauthorizedError'
+                500:
+                    description: Unexpected error
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+    /api/pvt/db/clear-flattener:
+        patch:
+            summary: Reflatten a document.
+            description: Clears the appropriate columns in the Unified Platform database so that the `flattener` container service processes the document to flatten it again.
+            requestBody:
+                description: The list of document ids to clear flattener columns for
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/DocumentIdsArray'
+            responses:
+                204:
+                    description: Success
+                400:
+                    description: Bad Request
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                            examples:
+                                noIdsKey:
+                                    value:
+                                        error: 'Body must contain a key "ids"'
+                                badIdsFormat:
+                                    value:
+                                        error: '"ids" must be an Array of document ids'
+                                noBodyError:
+                                    value:
+                                        error: 'No Body'
+                401:
+                    $ref: '#/components/responses/UnauthorizedError'
+                500:
+                    description: Unexpected error
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+    /api/pvt/db/clear-flattener/all:
+        patch:
+            summary: Reflatten ALL documents.
+            description: >
+                **Use with Caution**
+                  - Clears the appropriate columns in the Unified Platform database so that the `flattener` container service processes all documents to flatten them again.
+            responses:
+                204:
+                    description: Success
+                401:
+                    $ref: '#/components/responses/UnauthorizedError'
+                500:
+                    description: Unexpected error
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+    /api/pvt/db/clear-lakify:
+        patch:
+            summary: Relakify a document.
+            description: Clears the appropriate columns in the Unified Platform database so that the `lakify` container service processes the document to lakify it again.
+            requestBody:
+                description: The list of document ids to clear lakify columns for
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/DocumentIdsArray'
+            responses:
+                204:
+                    description: Success
+                400:
+                    description: Bad Request
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                            examples:
+                                noIdsKey:
+                                    value:
+                                        error: 'Body must contain a key "ids"'
+                                badIdsFormat:
+                                    value:
+                                        error: '"ids" must be an Array of document ids'
+                                noBodyError:
+                                    value:
+                                        error: 'No Body'
+                401:
+                    $ref: '#/components/responses/UnauthorizedError'
+                500:
+                    description: Unexpected error
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+    /api/pvt/db/clear-lakify/all:
+        patch:
+            summary: Relakify ALL documents.
+            description: >
+                **Use with Caution**
+                  - Clears the appropriate columns in the Unified Platform database so that the `lakify` container service processes ALL documents to relakify them again.
+            responses:
+                204:
+                    description: Success
+                401:
+                    $ref: '#/components/responses/UnauthorizedError'
+                500:
+                    description: Unexpected error
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+    /api/pvt/db/solr-reindex:
+        patch:
+            summary: Reindex (resolrize) a document.
+            description: Sets a flag in the Unified Platform database so that the `solrize` container service processes the document to reindex it into Solr.
+            requestBody:
+                description: The list of document ids to reindex
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/DocumentIdsArray'
+            responses:
+                204:
+                    description: Success
+                400:
+                    description: Bad Request
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                            examples:
+                                noIdsKey:
+                                    value:
+                                        error: 'Body must contain a key "ids"'
+                                badIdsFormat:
+                                    value:
+                                        error: '"ids" must be an Array of document ids'
+                                noBodyError:
+                                    value:
+                                        error: 'No Body'
+                401:
+                    $ref: '#/components/responses/UnauthorizedError'
+                500:
+                    description: Unexpected error
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+    /api/pvt/db/solr-reindex/all:
+        patch:
+            summary: Reindex (resolrize) ALL documents.
+            description: >
+                **Use with Caution**
+                  - Sets flags in the Unified Platform database so that the `solrize` container service processes ALL documents to reindex them into Solr.
+            responses:
+                204:
+                    description: Success
+                401:
+                    $ref: '#/components/responses/UnauthorizedError'
+                500:
+                    description: Unexpected error
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+    /api/pvt/solr/create-collections:
+        post:
+            summary: Create new collections in Solr for a reindex.
+            requestBody:
+                description: The configuration information for the new collections
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                newVersion:
+                                    type: integer
+                                collections:
+                                    type: array
+                                    items:
+                                        description: new collections to create
+                                        type: object
+                                        properties:
+                                            name:
+                                                description: collection name
+                                                type: string
+                                            alias:
+                                                description: solrize alias
+                                                type: string
+                                            config:
+                                                type: object
+                                                properties:
+                                                    collection.configName:
+                                                        type: string
+                                                    numShards:
+                                                        type: integer
+                                                    replicationFactor:
+                                                        type: integer
+                            example:
+                                newVersion: 2
+                                collections:
+                                    - name: activity
+                                      alias: activity_solrize
+                                      config:
+                                          collection.configName: 'activity_configset_2'
+                                          numShards: 1
+                                          replicationFactor: 1
+                                    - name: budget
+                                      alias: budget_solrize
+                                      config:
+                                          collection.configName: 'budget_configset_2'
+                                          numShards: 1
+                                          replicationFactor: 1
+                                    - name: transaction
+                                      alias: transaction_solrize
+                                      config:
+                                          collection.configName: 'transaction_configset_2'
+                                          numShards: 1
+                                          replicationFactor: 1
+            responses:
+                204:
+                    description: Success
+                400:
+                    description: Bad Request
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                            examples:
+                                noIdsKey:
+                                    value:
+                                        error: 'Body must contain a key "<key>"'
+                                badCollectionsFormat:
+                                    value:
+                                        error: '"collections" must be an Array of collection objects'
+                                noBodyError:
+                                    value:
+                                        error: 'No Body'
+                401:
+                    $ref: '#/components/responses/UnauthorizedError'
+                500:
+                    description: Unexpected error
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+    /api/orchestrators/DownloadOrchestrator:
+        post:
+            summary: Downloads a Solr query.
+            description: Downloads the provided Solr query in the specified format to Azure Blobs and returns URL where it can be downloaded from. Uses Azure Functions [async-http](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-overview?tabs=javascript#async-http) pattern.
+            requestBody:
+                description: The query and format to download
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            properties:
+                                query:
+                                    description: The Solr query to request for download
+                                    type: string
+                                format:
+                                    description: The format to save the download in
+                                    type: string
+                                    example:
+                                        enum:
+                                            - 'JSON'
+                                            - 'XML'
+                                            - 'CSV'
+                                            - 'EXCEL'
+            responses:
+                202:
+                    description: Accepted
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/OrchestratorResponse'
+                401:
+                    $ref: '#/components/responses/UnauthorizedError'
+                500:
+                    description: Unexpected error
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+
+components:
+    responses:
+        UnauthorizedError:
+            description: API key is missing or invalid
+    schemas:
+        DocumentIdsArray:
+            type: object
+            properties:
+                ids:
+                    type: array
+                    items:
+                        description: document ids
+                        type: string
+                        example: '971828f5-d7ca-40b5-ae38-2fd4c11846e0'
+        Error:
+            type: object
+            required:
+                - error
+            properties:
+                error:
+                    description: A human readable error message
+                    type: string
+        ResponseMessage:
+            type: object
+            required:
+                - message
+            properties:
+                message:
+                    description: A human readable response message
+                    type: string
+        OrchestratorResponse:
+            type: object
+            properties:
+                id:
+                    type: string
+                statusQueryGetUri:
+                    type: string
+                sendEventPostUri:
+                    type: string
+                terminatePostUri:
+                    type: string
+                rewindPostUri:
+                    type: string
+                purgeHistoryDeleteUri:
+                    type: string
+                restartPostUri:
+                    type: string
+                suspendPostUri:
+                    type: string
+                resumePostUri:
+                    type: string
+            additionalProperties: false
+            required:
+                - id
+                - statusQueryGetUri
+                - sendEventPostUri
+                - terminatePostUri
+                - rewindPostUri
+                - purgeHistoryDeleteUri
+                - restartPostUri
+                - suspendPostUri
+                - resumePostUri
+    securitySchemes:
+        ApiKeyHeader:
+            type: apiKey
+            in: header
+            name: x-functions-key
+        ApiKeyQuery:
+            type: apiKey
+            in: query
+            name: x-functions-key
+security:
+    - ApiKeyHeader: []
+    - ApiKeyQuery: []


### PR DESCRIPTION
- add openapi spec
- fix description
- update summary and descriptions
- Bump eslint from 8.28.0 to 8.29.0 (#223)
- Bump prettier from 2.8.0 to 2.8.1 (#224)
- Bump fastify/github-action-merge-dependabot from 3.5.2 to 3.5.3 (#225)
- Bump eslint from 8.29.0 to 8.30.0 (#226)
- Bump eslint-config-prettier from 8.5.0 to 8.6.0 (#227)
- Bump eslint from 8.30.0 to 8.31.0 (#228)
- Bump husky from 8.0.2 to 8.0.3 (#229)
- Bump fastify/github-action-merge-dependabot from 3.5.3 to 3.5.4 (#230)
- use solr cursor pagination for downloading XML format
- Bump chardet from 1.5.0 to 1.5.1 (#232)
